### PR TITLE
[fix]インデックスをランダムに取得する箇所のバグを修正

### DIFF
--- a/src/algorithm/random_solver.py
+++ b/src/algorithm/random_solver.py
@@ -68,7 +68,7 @@ class RandomSolver(Solver):
         for j in range(100):
             parallel_translation_x = int(random.uniform(0, Field.field_x_size))
             parallel_translation_y = int(random.uniform(0, Field.field_y_size))
-            stamp_object_count = int(random.uniform(0, len(instance.stamp_object_list)-1))
+            stamp_object_count = random.randint(0, len(instance.stamp_object_list)-1)
             temp_solution.add_stamp_answer(instance.stamp_object_list[stamp_object_count].idx,
                                            parallel_translation_x,
                                            parallel_translation_y)

--- a/src/algorithm/random_solver.py
+++ b/src/algorithm/random_solver.py
@@ -66,8 +66,8 @@ class RandomSolver(Solver):
 
         #  スタンプを100回押した結果のSolution、Fieldクラスのオブジェクトを生成する
         for j in range(100):
-            parallel_translation_x = int(random.uniform(0, Field.field_x_size))
-            parallel_translation_y = int(random.uniform(0, Field.field_y_size))
+            parallel_translation_x = random.randint(0, Field.field_x_size)
+            parallel_translation_y = random.randint(0, Field.field_y_size)
             stamp_object_count = random.randint(0, len(instance.stamp_object_list)-1)
             temp_solution.add_stamp_answer(instance.stamp_object_list[stamp_object_count].idx,
                                            parallel_translation_x,


### PR DESCRIPTION
スタンプが2つ存在する問題において、random_solver でインデクス0のスタンプのみが押されるバグを修正。

### バグの原因
`random.uniform(a, b)` は a <= x <= b を満たす浮動小数 x を生成する。
https://docs.python.org/ja/3/library/random.html
したがって、 `random.uniform(0,1)` は 0 <= x <= 1 となる x を生成する。
このような x を `int() `で丸めると必ず 0 になるため、インデクス0のスタンプのみが押されていた。
`random.uniform()` ではなく `random.randint()` を使うのが正しいと思われる。