### PR TITLE
スタンプが正方形かどうか判定するメソッドを追加

### DIFF
--- a/exec/exec.py
+++ b/exec/exec.py
@@ -3,6 +3,7 @@ sys.path.append("../")
 from src.model.instance import Instance
 from src.util.io import IO
 from src.algorithm.random_solver import RandomSolver
+from src.algorithm.combined_stamp_maker import CombinedStampMaker
 
 # 問題の読み取り
 io = IO()
@@ -11,7 +12,7 @@ instance = Instance()
 instance.set_origin_stamp_object(io.stamp_object_list)
 
 # できるだけ面積の小さいcombined stampの作成
-instance.make_combined_stamp_list()
+instance = CombinedStampMaker.make_combined_stamp_instance(instance)
 
 # ソルバーの生成 & 解の計算
 solver = RandomSolver() # ここを切り替えることによって実行するアルゴリズムを変更できる

--- a/src/algorithm/combined_stamp_maker.py
+++ b/src/algorithm/combined_stamp_maker.py
@@ -1,4 +1,5 @@
 import sys
+import copy
 sys.path.append("../../")
 from src.model.stamp import Stamp
 
@@ -11,7 +12,8 @@ class CombinedStampMaker():
     def __init__(self):
         pass
 
-    def make_combined_stamp(instance):
+    @staticmethod
+    def make_combined_stamp_instance(instance):
         """
         与えられたインスタンス中のスタンプを用いて、できるだけ黒いセルの少ないスタンプを構成する。
 
@@ -26,7 +28,10 @@ class CombinedStampMaker():
         　combined stamp object listにスタンプを詰め込んだInstanceオブジェクト
         
         """
-        # TODO 実装する
+        # TODO ちゃんと実装する。とりあえずoriginスタンプをそのままcombinedスタンプとして使う
+        new_instance = copy.deepcopy(instance)
+        new_instance.combined_stamp_object_list = copy.deepcopy(new_instance.origin_stamp_object_list)
+        return new_instance
     
     @staticmethod
     def __is_rectangle(stamp_object):

--- a/src/algorithm/combined_stamp_maker.py
+++ b/src/algorithm/combined_stamp_maker.py
@@ -1,0 +1,99 @@
+import sys
+sys.path.append("../../")
+from src.model.stamp import Stamp
+
+class CombinedStampMaker():
+    """
+    Combined Stamp を作成するクラス。
+    与えられたインスタンス中のoriginal stampを使ってできるだけ面積の小さいCombined Stampを作成する。
+    """
+
+    def __init__(self):
+        pass
+
+    def make_combined_stamp(instance):
+        """
+        与えられたインスタンス中のスタンプを用いて、できるだけ黒いセルの少ないスタンプを構成する。
+
+        Parameters
+        ----------
+        instance : Instance
+        　combined stamp object list が空のInstanceオブジェクト
+
+        Returns
+        ----------
+        new_instance : Instance
+        　combined stamp object listにスタンプを詰め込んだInstanceオブジェクト
+        
+        """
+        # TODO 実装する
+    
+    @staticmethod
+    def __is_rectangle(stamp_object):
+        """
+        与えられたスタンプが長方形か判定する。
+
+        Parameters
+        ----------
+        stamp_object : Stamp
+        　判定する対象のStampオブジェクト
+
+        Returns
+        ----------
+        　長方形の場合True, そうでない場合False
+        """
+        black_cell_coordinate = stamp_object.get_black_cell_coordinate()
+
+        # 黒のセルのx座標とy座標の最大値/最小値をそれぞれ求める
+        x_max = 0
+        x_min = stamp_object.stamp_x_size
+        y_max = 0
+        y_min = stamp_object.stamp_y_size
+        for ind_y in range(stamp_object.stamp_y_size):
+            for ind_x in range(stamp_object.stamp_x_size):
+                if (ind_y, ind_x) in black_cell_coordinate:
+                    x_max = max(x_max, ind_x)
+                    x_min = min(x_min, ind_x)
+                    y_max = max(y_max, ind_y)
+                    y_min = min(y_min, ind_y)
+        
+        # 黒いセルの面積と、(x座標の最大値-最小値+1)*(y座標の最大値-最小値+1)が等しければ長方形
+        return (x_max-x_min+1) * (y_max-y_min+1) == len(black_cell_coordinate)
+                    
+
+if __name__ == "__main__":
+    # 1. __is_rectangle Test
+
+    # Case 1-1. 長方形の場合
+    # 00111
+    # 00111
+    # 00111
+    # 00000
+    stamp1_1 = Stamp(input_str="5;4;00111001110011100000")
+    assert CombinedStampMaker._CombinedStampMaker__is_rectangle(stamp1_1), "Case 1-1. Fail!"
+
+    # Case 1-2. 長方形でない場合
+    # 1000
+    # 0100
+    # 0010
+    # 0001
+    # 1111
+    stamp1_2 = Stamp(input_str="4;5;10000100001000011111")
+    assert (not CombinedStampMaker._CombinedStampMaker__is_rectangle(stamp1_2)), "Case 1-2. Fail!"
+
+    # Case 1-3. コーナーケース（長方形が2つ)
+    # 1100
+    # 1100
+    # 0011
+    # 0011
+    stamp1_3 = Stamp(input_str="4;4;1100110000110011")
+    assert (not CombinedStampMaker._CombinedStampMaker__is_rectangle(stamp1_3)), "Case 1-3. Fail!"
+
+
+    # Case1-4. コーナーケース（面積が1）
+    # 0000
+    # 0000
+    # 0010
+    # 0000
+    stamp1_4 = Stamp(input_str="4;4;0000000000100000")
+    assert CombinedStampMaker._CombinedStampMaker__is_rectangle(stamp1_4), "Case 1-4. Fail!"

--- a/src/model/instance.py
+++ b/src/model/instance.py
@@ -17,8 +17,8 @@ class Instance:
 
         """
 
-        self.origin_stamp_object_list = []
-        self.combined_stamp_object_list = []
+        self.__origin_stamp_object_list = []
+        self.__combined_stamp_object_list = []
 
     def set_origin_stamp_object(self, stamp_object):
         """
@@ -29,12 +29,18 @@ class Instance:
             Stampクラスのオブジェクト。
         """
 
-        self.origin_stamp_object_list.extend(stamp_object)
+        self.__origin_stamp_object_list.extend(stamp_object)
+    
+    def get_origin_stamp_object_list(self):
+        """
+        origin stamp object listをゲットする。
 
-    # できるだけ面積の小さい combined stamp を構築する
-    def make_combined_stamp_list(self):
-        # TODO: 実装する。ひとまず、original stamp をそのまま使う。
-        self.combined_stamp_object_list = copy.deepcopy(self.origin_stamp_object_list)
+        Returns
+        ----------
+        combined_stamp_object_list : list-array
+            Stampクラスのオブジェクトを格納するリスト。
+        """
+        return self.__origin_stamp_object_list
 
     def get_combined_stamp_object_list(self):
         """
@@ -46,10 +52,4 @@ class Instance:
             Stampクラスのオブジェクトを格納するリスト。
         """
 
-        return self.combined_stamp_object_list
-
-
-if __name__ == "__main__":
-    temp_instance = Instance()
-    temp_instance.set_stamp_object("aaaa")
-    print(temp_instance.get_combined_stamp_object_list())
+        return self.__combined_stamp_object_list

--- a/src/model/instance.py
+++ b/src/model/instance.py
@@ -17,8 +17,8 @@ class Instance:
 
         """
 
-        self.__origin_stamp_object_list = []
-        self.__combined_stamp_object_list = []
+        self.origin_stamp_object_list = []
+        self.combined_stamp_object_list = []
 
     def set_origin_stamp_object(self, stamp_object):
         """
@@ -29,7 +29,7 @@ class Instance:
             Stampクラスのオブジェクト。
         """
 
-        self.__origin_stamp_object_list.extend(stamp_object)
+        self.origin_stamp_object_list.extend(stamp_object)
     
     def get_origin_stamp_object_list(self):
         """
@@ -40,7 +40,7 @@ class Instance:
         combined_stamp_object_list : list-array
             Stampクラスのオブジェクトを格納するリスト。
         """
-        return self.__origin_stamp_object_list
+        return self.origin_stamp_object_list
 
     def get_combined_stamp_object_list(self):
         """
@@ -52,4 +52,4 @@ class Instance:
             Stampクラスのオブジェクトを格納するリスト。
         """
 
-        return self.__combined_stamp_object_list
+        return self.combined_stamp_object_list

--- a/src/model/stamp.py
+++ b/src/model/stamp.py
@@ -68,7 +68,7 @@ class Stamp:
         return self.origin_stamp_list
 
 if __name__ == "__main__":
-    temp_stamp = Stamp(1, input_str="4;5;10000100001000011111")
+    temp_stamp = Stamp(0, "4;5;10000100001000011111")
     print(temp_stamp.get_black_cell_coordinate())
 
 

--- a/src/model/stamp.py
+++ b/src/model/stamp.py
@@ -17,7 +17,7 @@ class Stamp:
         スタンプの黒いセルの座標を格納する配列
     """
 
-    def __init__(self, idx, input_str):
+    def __init__(self, idx=-1, input_str=""):
         """
         引数ありのコンストラクタ。
 
@@ -68,7 +68,7 @@ class Stamp:
         return self.origin_stamp_list
 
 if __name__ == "__main__":
-    temp_stamp = Stamp(0, "4;5;10000100001000011111")
+    temp_stamp = Stamp(1, input_str="4;5;10000100001000011111")
     print(temp_stamp.get_black_cell_coordinate())
 
 


### PR DESCRIPTION
面積が1のセルを求める対応の1つ目です。
プルリクが大きくなってしまいそうなので対応をいくつかに分けることにしました。

今回の対応には以下の差分が含まれています：

1. CombinedStampMakerクラスを追加。
2. 与えられたスタンプが長方形か判定するメソッド（CombinedStampMaker#__is_rectangle() ）およびその単体テストを追加
3. CombinedStampMakerの呼び出し元（exec.py）の呼び出し方を修正

### 申し送り事項
`python exec.py < problem1.txt` が正常終了することを確認しています。